### PR TITLE
Added a Compact Inbox userscript I worked on

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Here are some userscripts that have been provided by the community to help you c
 * **@axllent [Attachment Icons in Gmail](axllent/attachmenticons/userscript.css)** - adds basic attachment icons depending on filetype [CSS](axllent/attachmenticons/userscript.css)
 * **@Thomas101 [Hide Scrollbar in Inbox](Thomas101/hidescroll/userscript.css)** - hides the main scrollbar that flows over the titlebar in Google Inbox [CSS](Thomas101/hidescroll/userscript.css)
 * **@MichaelTunnell [Custom default font size](MichaelTunnell/custom-default-font-size)** - change the default font size in Gmail and Google Inbox [CSS](MichaelTunnell/custom-default-font-size/userscript.css) [README](MichaelTunnell/custom-default-font-size/README.md)
+* **@binamkayastha [CompactInbox](binamkayastha/CompactInbox)** - makes Google Inbox more compact [CSS](binamkayastha/CompactInbox/userscript.css)
 
 ---
 

--- a/binamkayastha/CompactInbox/userscript.css
+++ b/binamkayastha/CompactInbox/userscript.css
@@ -1,0 +1,31 @@
+/* Created by Binam Kayastha under GPL License. Maintained as a userscript here: https://github.com/binamkayastha/UserScripts/blob/master/Inbox/CompactInbox.js*/
+/* Increase width */
+.cM{width: 90%; padding-right: 4% !important;} .lQ{line-height: 20px !important;}
+.an{padding: 0px !important; margin: auto !important;}
+.jS{margin: 0px !important; min-height: 30px !important}
+
+/* Auto Align */
+.iG{margin: auto !important; /*img*/}
+.rv{margin: auto !important;}
+.rv{margin: auto !important;}
+.hY{margin: auto !important;}
+
+/* Remove shadow, add borders */
+.aa::before, .an::before{box-shadow: none !important; border: 1px solid #ddd; border-left: solid #ddd}
+
+/* Shrink Icon Sizes */
+.gi, .gN{width: 20px !important; height: 20px !important;}
+
+/* Change Font size */
+.ai-b8{font-size: 15px; font-weight: bold;}
+
+/* Removing/Decreasing empty space */
+.ai-b8{margin: 0px !important; margin-top: 8px}
+.az{padding: 5px !important; margin-bottom: 0px !important; margin-top: 10px !important}
+.kz{margin-bottom: 0px;}
+.g-aq.b0{padding: 2px 24px !important;}
+
+/* Shrinking Attachments */
+.cq{height: 24px !important;} .cq:hover{height: 88px !important;}
+.mp{height: 24px !important;}
+.ga{height: 24px !important;}


### PR DESCRIPTION
Basically makes the divs and attachments smaller so you can see more emails at once. Also resizes the width of the emails when sidebars are hidden.

It goes against material design, but it makes inbox more usable in my opinion. Currently maintaining it under one of my repositories, so I'll update it here periodically.

Hope you like it!