### PR TITLE
Octobox badge script

### DIFF
--- a/dctucker/octobox-badge/userscript.js
+++ b/dctucker/octobox-badge/userscript.js
@@ -1,0 +1,3 @@
+setInterval(function(){
+  window.wavebox.badge.setCount( parseInt(window.$('title').text().replace("Octobox (","")) )
+}, 2000);


### PR DESCRIPTION
As a Githubber who uses Wavebox
I want to see the number of my unread Octobox notifications in the badge
So that I can easily identify when attention is needed.

Since my number of unread notifications is non-zero for the foreseeable future, I haven't extended this script to cover any other cases. That will change once I get to inbox zero! Watch this space.