### PR TITLE
Add script to update badge for Gitter account

### DIFF
--- a/jason0x43/gitter-badge/README.md
+++ b/jason0x43/gitter-badge/README.md
@@ -1,0 +1,7 @@
+gitter-status
+=============
+
+This script updates the activity badge of a generic Wavebox container that's
+logged into Gitter. It works by looking at the activity status icons in the
+Gitter sidebar every 5 seconds, and then setting the container badge to show
+activity, or a count of unread messages if that's available.

--- a/jason0x43/gitter-badge/userscript.js
+++ b/jason0x43/gitter-badge/userscript.js
@@ -1,0 +1,27 @@
+setInterval(() => {
+  const count = getUnreadCount();
+  wavebox.badge.setCount(count);
+  if (count === 0) {
+    wavebox.badge.setHasUnreadActivity(hasActivity());
+  }
+}, 5000);
+
+function hasActivity() {
+  return (
+    document.querySelector(
+      '.room-menu .room-item__unread-indicator.has-activity'
+    ) != null
+  );
+}
+
+function getUnreadCount() {
+  const unreads = Array.from(
+    document.querySelectorAll(
+      '.room-menu .room-item__unread-indicator.has-unreads'
+    )
+  );
+  return unreads.reduce(
+    (total, node) => total + Number(node.textContent.trim()),
+    0
+  );
+}


### PR DESCRIPTION
This is a userscript that will update the activity badge for a Gitter container (a generic container logged into Gitter).