### PR TITLE
WhatsApp Web: Custom Wallpapers

### DIFF
--- a/cornehoskam/WhatsAppWeb/userscript.css
+++ b/cornehoskam/WhatsAppWeb/userscript.css
@@ -1,0 +1,12 @@
+html[dir] ._1FPJ-:after {
+    visibility: hidden;
+}
+
+html[dir] ._3RWII{
+	width: 40px !important;
+	height: 40px !important;
+	}
+
+body {
+     background-image: url("https://source.unsplash.com/4096x2160/?coffee,nature");
+}

--- a/cornehoskam/WhatsAppWeb/userscript.css
+++ b/cornehoskam/WhatsAppWeb/userscript.css
@@ -5,7 +5,7 @@ html[dir] ._1FPJ-:after {
 html[dir] ._3RWII{
 	width: 40px !important;
 	height: 40px !important;
-	}
+}
 
 body {
      background-image: url("https://source.unsplash.com/4096x2160/?coffee,nature");


### PR DESCRIPTION
I've always hated the way the default WhatsApp Web looked. Hereby a custom piece of CSS that removes the thick green bar at the top, and replaces the wallpaper behind the chat with a random one gathered from the Unsplash API.
This script specifically will fetch a 4k imagine that match the search queries Coffee, or Nature.